### PR TITLE
TableViewの行数をレスポンスデータの件数から取得

### DIFF
--- a/ios-training/Controller/WeatherListViewController.swift
+++ b/ios-training/Controller/WeatherListViewController.swift
@@ -121,7 +121,7 @@ extension WeatherListViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return cities.count
+        return weatherList.count
     }
 }
 

--- a/ios-training/Controller/WeatherListViewController.swift
+++ b/ios-training/Controller/WeatherListViewController.swift
@@ -99,8 +99,6 @@ extension WeatherListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: WeatherListCell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as! WeatherListCell
         
-        guard weatherList.count > 0 else { return cell }
-        
         cell.weatherImageView.image = UIImage(named: weatherList[indexPath.row].info.weatherCondition.rawValue)
         
         switch weatherList[indexPath.row].info.weatherCondition {


### PR DESCRIPTION
## 対応内容

TableViewの行数をcityからレスポンス(weatherList)の件数から取得するよう修正。

cityで指定していたことで以下の問題が発生していた。

* データ取得前に固定値でcityの件数分の行数が指定されるため、データがbindされていないセルが描画される
* データ取得前にテーブルの行数 > レスポンスの件数となることでIndex out of rangeが発生

上記に伴い、gaurdを削除。

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/75c295f3c840f6b69a4083746b262daa.gif)](https://gyazo.com/75c295f3c840f6b69a4083746b262daa)

## 関連URL

https://ios-dev-arcadit.slack.com/archives/C046KTHAT54/p1677365542430279?thread_ts=1677274625.464189&cid=C046KTHAT54

## 備考

- 特になし




